### PR TITLE
Add SEO plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 plugins:
   - jekyll-sitemap
+  - jekyll-seo-tag
 exclude:
   - Gruntfile.js
   - package.json

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
     <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple-dark.css">
     <link rel="stylesheet" href="include/css/style.css" media="all">
     <link rel="stylesheet" href="include/css/print.css" media="print">
+    {% seo %}
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
Allow this : https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md